### PR TITLE
Fix template tag for Django 4+

### DIFF
--- a/django_messages/templates/django_messages/view.html
+++ b/django_messages/templates/django_messages/view.html
@@ -15,9 +15,9 @@
 </dl>
 {{ message.body|linebreaksbr }}<br /><br />
 
-{% ifequal message.recipient.pk user.pk %}
+{% if message.recipient.pk == user.pk %}
 <a href="{% url 'messages_reply' message.id %}">{% trans "Reply" %}</a>
-{% endifequal %}
+{% endif %}
 <a href="{% url 'messages_delete' message.id %}">{% trans "Delete" %}</a>
 
 {% comment %}Example reply_form integration


### PR DESCRIPTION
## Summary
- update `view.html` to remove deprecated `ifequal` tag

## Testing
- `python tests/manage.py test django_messages --settings=settings`

------
https://chatgpt.com/codex/tasks/task_e_68448d6b3558832a9e551475a0dbf624