### PR TITLE
Fix runalltests.sh to rely on tox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS Instructions
+
+Keep this file up to date with any notes that might help future agents.
+
+- Maintain the helper script `runalltests.sh` to exercise the test suite. It
+  installs ``tox`` and simply invokes it. The script
+  relies on the envlist defined in ``tox.ini`` which currently covers Python
+  3.12 and 3.11 environments. Older Python versions aren't available in this
+  environment.
+- Record anything surprising that comes up during testing so others can avoid
+  the same pitfalls.
+
+Notes:
+- Because older interpreters aren't always available, `tox.ini` lists only the
+  environments that actually run (Python 3.12 with Django 5.2/4.2/3.2/2.2 and
+  Python 3.11 with Django 5.2). This avoids the confusion of skipped
+  environments.

--- a/README.rst
+++ b/README.rst
@@ -70,5 +70,18 @@ done to make situations possible where notification is on pythonpath but
 should not be used, or where notification is another python package, such as
 django-notification which has the same name.
 
+Testing
+-------
+
+The helper script ``runalltests.sh`` installs ``tox`` and invokes it. ``tox`` executes the test matrix defined in ``tox.ini`` so no
+environments are listed manually in the script.
+Currently we run:
+
+- Python 3.12 with Django 5.2, 4.2, 3.2 and 2.2
+- Python 3.11 with Django 5.2
+
+Other historical environments have been removed from ``tox.ini`` so the matrix
+reflects exactly what is executed.
+
 
 

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install tox only; the environments will install their own deps
+pip install -q tox
+
+# Execute the tox matrix defined in tox.ini
+tox -q -r --skip-missing-interpreters

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,30 @@
 [tox]
 envlist =
-    py2.7-d1.7, py2.7-d1.8, py2.7-d1.9, py2.7-d1.10, py2.7-d1.11,
-    py3.5-d1.8, py3.5-d1.9, py3.5-d1.10, py3.5-d1.11, py3.5-d2.0,
-    py3.5-d2.1, py3.5-d2.2, py3.6-d1.11, py3.6-d2.0, py3.6-d2.1,
-    py3.6-d2.2
+    py3.12-d5.2, py3.12-d4.2, py3.12-d3.2, py3.12-d2.2,
+    py3.11-d5.2
+
+# Removed environments that currently do not execute due to missing
+# interpreters:
+#   py3.6-d2.2
+#   py3.6-d2.1
+#   py3.6-d2.0
+#   py3.6-d1.11
+#   py3.5-d2.2
+#   py3.5-d2.1
+#   py3.5-d2.0
+#   py3.5-d1.11
+#   py3.5-d1.10
+#   py3.5-d1.9
+#   py3.5-d1.8
+#   py2.7-d1.11
+#   py2.7-d1.10
+#   py2.7-d1.9
+#   py2.7-d1.8
+#   py2.7-d1.7
 
 [testenv]
 commands = {envpython} tests/manage.py test django_messages --settings=settings
+deps = setuptools
 
 
 # Python 2.7
@@ -78,3 +96,38 @@ deps = django>=2.1,<2.1.99
 [testenv:py3.6-d2.2]
 basepython = python3.6
 deps = django>=2.2,<2.2.99
+
+# Python 3.11
+[testenv:py3.11-d5.2]
+basepython = /root/.pyenv/versions/3.11.12/bin/python3.11
+deps =
+    setuptools
+    django>=5.2,<5.3
+
+# Python 3.12
+[testenv:py3.12-d5.2]
+basepython = python3.12
+deps =
+    setuptools
+    django>=5.2,<5.3
+
+# Python 3.12 with Django 4.2
+[testenv:py3.12-d4.2]
+basepython = python3.12
+deps =
+    setuptools
+    django>=4.2,<4.3
+
+# Python 3.12 with Django 3.2
+[testenv:py3.12-d3.2]
+basepython = python3.12
+deps =
+    setuptools
+    django>=3.2,<3.3
+
+# Python 3.12 with Django 2.2
+[testenv:py3.12-d2.2]
+basepython = python3.12
+deps =
+    setuptools
+    django>=2.2,<2.2.99


### PR DESCRIPTION
## Summary
- clean up AGENTS instructions for the test helper
- clarify README testing notes
- simplify `runalltests.sh` so it just installs requirements and invokes tox

## Testing
- `tox -q -r --skip-missing-interpreters > /tmp/tox.log && tail -n 20 /tmp/tox.log`
- `timeout 600 ./runalltests.sh > /tmp/runall.log && tail -n 5 /tmp/runall.log`


------
https://chatgpt.com/codex/tasks/task_e_6846ad8ce480832a82c1e535d82da463