### PR TITLE
Add template regression test and note about running tox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,6 @@ Notes:
   environments that actually run (Python 3.12 with Django 5.2/4.2/3.2/2.2 and
   Python 3.11 with Django 5.2). This avoids the confusion of skipped
   environments.
+- Running the entire tox matrix can be time consuming. When iterating locally,
+  it's usually enough to execute a single environment, e.g. ``./runalltests.sh
+  -e py3.12-d5.2``.

--- a/django_messages/tests.py
+++ b/django_messages/tests.py
@@ -271,3 +271,34 @@ class RecipientFilterTestCase(TestCase):
         )
         assert not form.is_valid()
         assert self.user2.username in force_str(form.errors)
+
+
+class ViewMessageTemplateTestCase(TestCase):
+    """Ensure the message detail template renders correctly."""
+
+    def setUp(self):
+        self.sender = User.objects.create_user(
+            "sender", "sender@example.com", "123456"
+        )
+        self.recipient = User.objects.create_user(
+            "recipient", "recipient@example.com", "123456"
+        )
+        self.message = Message.objects.create(
+            sender=self.sender,
+            recipient=self.recipient,
+            subject="Subject",
+            body="Body",
+        )
+        self.client = Client()
+
+    def test_detail_view_renders(self):
+        """Viewing a message should render without template errors."""
+        assert self.client.login(username="recipient", password="123456")
+        response = self.client.get(
+            reverse("messages_detail", args=[self.message.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse("messages_reply", args=[self.message.pk]),
+        )

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -4,5 +4,8 @@ set -euo pipefail
 # Install tox only; the environments will install their own deps
 pip install -q tox
 
-# Execute the tox matrix defined in tox.ini
-tox -q -r --skip-missing-interpreters
+# Execute the tox matrix defined in tox.ini unless arguments specify
+# particular environments. Pass any given arguments directly to ``tox``
+# so callers may run a subset of environments, e.g. ``./runalltests.sh -e
+# py3.12-d5.2``.
+tox -q -r --skip-missing-interpreters "$@"


### PR DESCRIPTION
## Summary
- add instructions for running a single tox env in `AGENTS.md`
- allow `runalltests.sh` to accept env arguments
- add regression test ensuring message detail view renders correctly

## Testing
- `./runalltests.sh -e py3.12-d5.2`

------
https://chatgpt.com/codex/tasks/task_e_68470d9baa64832aa6fae407f8efddcd