### PR TITLE
Add default_auto_field setting

### DIFF
--- a/django_messages/apps.py
+++ b/django_messages/apps.py
@@ -2,5 +2,6 @@ from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 
 class DjangoMessagesConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'django_messages'
     verbose_name = _('Messages')


### PR DESCRIPTION
## Summary
- add `default_auto_field` to DjangoMessagesConfig to suppress Django 3.2 warnings

## Testing
- `./runalltests.sh -e py3.12-d5.2`

------
https://chatgpt.com/codex/tasks/task_e_68474261e610832a8b8a85f2a0db6308