### PR TITLE
Expand tox matrix

### DIFF
--- a/runalltests.sh
+++ b/runalltests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install tox only; the environments will install their own deps
-pip install -q tox
+# Install tox and setuptools only; the environments will install their own deps
+pip install -q tox setuptools
 
 # Execute the tox matrix defined in tox.ini unless arguments specify
 # particular environments. Pass any given arguments directly to ``tox``

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py3.12-d5.2, py3.12-d4.2, py3.12-d3.2, py3.12-d2.2,
-    py3.11-d5.2
+    py3.11-d5.2,
+    py3.9-d5.2, py3.9-d4.2, py3.9-d3.2, py3.9-d2.2, py3.9-d2.1, py3.9-d2.0
 
 # Removed environments that currently do not execute due to missing
 # interpreters:
@@ -24,7 +25,8 @@ envlist =
 
 [testenv]
 commands = {envpython} tests/manage.py test django_messages --settings=settings
-deps = setuptools
+deps =
+sitepackages = True
 
 
 # Python 2.7
@@ -99,35 +101,61 @@ deps = django>=2.2,<2.2.99
 
 # Python 3.11
 [testenv:py3.11-d5.2]
-basepython = /root/.pyenv/versions/3.11.12/bin/python3.11
+basepython = python3.11
 deps =
-    setuptools
     django>=5.2,<5.3
 
 # Python 3.12
 [testenv:py3.12-d5.2]
 basepython = python3.12
 deps =
-    setuptools
     django>=5.2,<5.3
 
 # Python 3.12 with Django 4.2
 [testenv:py3.12-d4.2]
 basepython = python3.12
 deps =
-    setuptools
     django>=4.2,<4.3
 
 # Python 3.12 with Django 3.2
 [testenv:py3.12-d3.2]
 basepython = python3.12
 deps =
-    setuptools
     django>=3.2,<3.3
 
 # Python 3.12 with Django 2.2
 [testenv:py3.12-d2.2]
 basepython = python3.12
 deps =
-    setuptools
     django>=2.2,<2.2.99
+
+# Python 3.9
+[testenv:py3.9-d5.2]
+basepython = python3.9
+deps =
+    django>=5.2,<5.3
+
+[testenv:py3.9-d4.2]
+basepython = python3.9
+deps =
+    django>=4.2,<4.3
+
+[testenv:py3.9-d3.2]
+basepython = python3.9
+deps =
+    django>=3.2,<3.3
+
+[testenv:py3.9-d2.2]
+basepython = python3.9
+deps =
+    django>=2.2,<2.2.99
+
+[testenv:py3.9-d2.1]
+basepython = python3.9
+deps =
+    django>=2.1,<2.1.99
+
+[testenv:py3.9-d2.0]
+basepython = python3.9
+deps =
+    django>=2.0,<2.0.99


### PR DESCRIPTION
## Summary
- install setuptools when setting up test helper
- add py3.9 environments and use python3.11 instead of the pyenv path
- remove setuptools from tox deps and enable site packages

## Testing
- `./runalltests.sh` *(fails: py3.12-d3.2 exit code -15)*

------
https://chatgpt.com/codex/tasks/task_e_68474db1bab8832ab0b5bf39a813a49f